### PR TITLE
Prep for repo move to linkerd org

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,4 @@ open localhost:3000
 ## Mesos + Marathon Deploy
 
 For more deployment instructions, see the
-[mesos-marathon configs in the linkerd-examples repo](https://github.com/BuoyantIO/linkerd-examples/tree/master/mesos-marathon).
+[mesos-marathon configs in the linkerd-examples repo](https://github.com/linkerd/linkerd-examples/tree/master/mesos-marathon).


### PR DESCRIPTION
This change is pretty sparse, since we're not renaming the docker image org as part of the repo move.