### PR TITLE
Add an upgrade notice to the top of README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Upgrade Notice
 
 This repo is for Linkerd 1. For instructions on setting up the Linkerd 2 viz
-extension, see the [Linkerd 2 documentation](https://linkerd.io/docs/).
+extension, see the [Linkerd 2 documentation](https://linkerd.io/2/tasks/extensions/).
 
 # linkerd-viz
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/buoyantio/linkerd-viz.svg)](https://hub.docker.com/r/buoyantio/linkerd-viz/)
 
+# Upgrade Notice
+
+This repo is for Linkerd 1. For instructions on setting up the Linkerd 2 viz
+extension, see the [Linkerd 2 documentation](https://linkerd.io/docs/).
+
 # linkerd-viz
 
 Dead simple monitoring for [linkerd](https://linkerd.io).


### PR DESCRIPTION
With the Linkerd 2 viz extension, we need to more clearly disambiguate
this repo.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

<img width="1012" alt="Screen Shot 2021-04-26 at 11 56 54 AM" src="https://user-images.githubusercontent.com/236915/116135897-8446e800-a686-11eb-8062-e3253ede718c.png">
